### PR TITLE
change the cmap input to ColorbarBase

### DIFF
--- a/oco2_modis_vistool.py
+++ b/oco2_modis_vistool.py
@@ -439,7 +439,8 @@ def do_modis_overlay_plot(
 
             cb_ax1 = plt.subplot(gs[0:-1, -1])
             norm = mpl.colors.Normalize(vmin = var_lims[0], vmax = var_lims[1])
-            cb1 = mpl.colorbar.ColorbarBase(cb_ax1, cmap=cmap, orientation = 'vertical', norm = norm)
+            cmap_obj = mpl.cm.get_cmap(cmap)
+            cb1 = mpl.colorbar.ColorbarBase(cb_ax1, cmap=cmap_obj, orientation = 'vertical', norm = norm)
             if var_label:
                 cb1_lab = cb1.ax.set_xlabel(var_label, labelpad=8, fontweight='bold')
                 cb1_lab.set_fontsize(14)


### PR DESCRIPTION
In MPL 3.1, setting the cmap with the string colormap name does not work. Instead, set the cmap with the LinearSegmentedColormap object. I think this should be backwardly compatible with older MPL (I did verify with MPL v2.2.3 at least).